### PR TITLE
fix: 사용자 image url 길이 수정

### DIFF
--- a/src/main/java/bigtech/fbai/member/dao/entity/Member.java
+++ b/src/main/java/bigtech/fbai/member/dao/entity/Member.java
@@ -2,6 +2,7 @@ package bigtech.fbai.member.dao.entity;
 
 import bigtech.fbai.common.exception.CommonException;
 import bigtech.fbai.common.exception.ErrorCode;
+import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
@@ -26,6 +27,7 @@ public class Member {
 
     private String introduce;
 
+    @Column(length = 500)
     private String imageUrl;
 
     public void update(String nickname, String imageUrl, String introduce) {


### PR DESCRIPTION
image url이 길어서 길이 초과가 되던 에러를 수정했습니다.

🚀 개요
close #45 

🔍 변경사항
- [ ] 새로운 기능 추가
- [x] 버그 수정
- [ ] CSS 등 사용자 UI 디자인 변경
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [ ] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [ ] 문서 수정
- [ ] 테스트 추가, 테스트 리팩토링
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제

📝 논의사항